### PR TITLE
Make STF compatible with silly compilers

### DIFF
--- a/include/stf/common/detail/nullptr_t.hpp
+++ b/include/stf/common/detail/nullptr_t.hpp
@@ -1,0 +1,21 @@
+//==================================================================================================
+/**
+  Copyright 2016 Joel Falcou
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef STF_COMMON_DETAIL_NULLPTR_T_HPP_INCLUDED
+#define STF_COMMON_DETAIL_NULLPTR_T_HPP_INCLUDED
+
+namespace stf { namespace detail
+{
+#if defined(STF_USE_INCOMPLETE_STD)
+  using nullptr_t = decltype(nullptr);
+#else
+  using nullptr_t = std::nullptr_t;
+#endif
+} }
+
+#endif

--- a/include/stf/common/detail/shuffle.hpp
+++ b/include/stf/common/detail/shuffle.hpp
@@ -1,0 +1,34 @@
+//==================================================================================================
+/**
+  Copyright 2016 Joel Falcou
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+**/
+//==================================================================================================
+#ifndef STF_COMMON_DETAIL_RANDOM_HPP_INCLUDED
+#define STF_COMMON_DETAIL_RANDOM_HPP_INCLUDED
+
+#include <algorithm>
+
+ namespace stf { namespace detail
+ {
+ #if defined(STF_USE_INCOMPLETE_STD)
+  template<typename RGenFct> struct URNGConv
+  {
+    int operator()(int) { return fct(); }
+    RGenFct fct;
+  };
+
+  template<typename RandomIt, typename RGenFct>
+  void shuffle(RandomIt const& begin, RandomIt const& end, RGenFct&& r)
+  {
+    URNGConv<RGenFct> wrp({r});
+    std::random_shuffle(begin, end, wrp);
+  }
+#else
+  using std::shuffle;
+#endif
+} }
+
+#endif

--- a/include/stf/common/driver.hpp
+++ b/include/stf/common/driver.hpp
@@ -17,6 +17,7 @@
 
 #include <stf/common/args.hpp>
 #include <stf/common/values.hpp>
+#include <stf/common/detail/shuffle.hpp>
 #include <algorithm>
 #include <random>
 
@@ -52,7 +53,7 @@ namespace stf
     // randomize test on non-null random seed option
     if(auto seed = args("random",0u))
     {
-      std::shuffle( tests.begin(), tests.end(), std::mt19937{seed} );
+      std::::stf::detail::shuffle( tests.begin(), tests.end(), std::mt19937{seed} );
     }
 
     for(auto& t : tests )

--- a/include/stf/common/driver.hpp
+++ b/include/stf/common/driver.hpp
@@ -53,7 +53,7 @@ namespace stf
     // randomize test on non-null random seed option
     if(auto seed = args("random",0u))
     {
-      std::::stf::detail::shuffle( tests.begin(), tests.end(), std::mt19937{seed} );
+      ::stf::detail::shuffle( tests.begin(), tests.end(), std::mt19937{seed} );
     }
 
     for(auto& t : tests )

--- a/include/stf/common/to_string.hpp
+++ b/include/stf/common/to_string.hpp
@@ -4,12 +4,10 @@
 
   Defines the to_string utility function
 
-  @copyright 2015 Joel Falcou
-
+  @copyright 2016 Joel Falcou
 
   Distributed under the Boost Software License, Version 1.0.
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
-
 **/
 //==================================================================================================
 #ifndef STF_COMMON_TO_STRING_HPP_INCLUDED
@@ -17,6 +15,7 @@
 
 #include <stf/common/detail/is_container.hpp>
 #include <stf/common/detail/is_streamable.hpp>
+#include <stf/common/detail/nullptr_t.hpp>
 #include <boost/core/demangle.hpp>
 #include <sstream>
 #include <cstddef>
@@ -25,11 +24,11 @@
 
 namespace stf
 {
-  inline std::string to_string( std::nullptr_t )        { return "nullptr";             }
-  inline std::string to_string( bool v )                { return v ? "true" : "false";  }
-  inline std::string to_string( std::string const& v )  { return v;                     }
-  inline std::string to_string( char const* v )         { return std::string(v);        }
-  inline std::string to_string( char v )                { return std::string(1, v);     }
+  inline std::string to_string( stf::detail::nullptr_t )  { return "nullptr";             }
+  inline std::string to_string( bool v )                  { return v ? "true" : "false";  }
+  inline std::string to_string( std::string const& v )    { return v;                     }
+  inline std::string to_string( char const* v )           { return std::string(v);        }
+  inline std::string to_string( char v )                  { return std::string(1, v);     }
 
   /*!
     @ingroup group-common


### PR DESCRIPTION
Some configuration of compilers found on some interesting platform (large-scale clusters) use strange compilers setup (e.g. icpc 15 + g++ 4.4) that makes some STD component unavailable.

This patch try to fix this by providing a STF_HAS_INCOMPLETE_STD macro trigger to use in cases where STF compilation is impaired by the lack of some proper standard components.